### PR TITLE
Fixed the incorrect variable name for dated locality url

### DIFF
--- a/html/browser.html
+++ b/html/browser.html
@@ -62,7 +62,7 @@
                         {{#if mineral-specimen.age-determination-process.remote-age.label}}
                             <sup>{{mineral-specimen.age-determination-process.remote-age.label}}</sup>
                             Remote Dated Locality:
-                            <a href="{{mineral-specimen.dated-locality-url}}" target="_blank">{{mineral-specimen.dated-locality-label}}</a>
+                            <a href="{{mineral-specimen.dated-locality-mindat-url}}" target="_blank">{{mineral-specimen.dated-locality-label}}</a>
                         {{/if}}
                     </div>
                     <div style="font-style: italic; text-indent: 20px">


### PR DESCRIPTION
Fixed #36 
Now the dated locality really link to the dated locality page on mindat. Tested.
