### PR TITLE
Badges added linking to RRUFF, Wikipedia, and Web Mineral

### DIFF
--- a/html/browser.html
+++ b/html/browser.html
@@ -83,9 +83,18 @@
                 {{/if}}
 
                 <div>
-                    <a href="http://rruff.info/mineral_list/locality.php?mineral_name={{mineral-species.mineral-name-plain}}" target="_blank"><strong>RRUFF</strong></a>
-                </div>
+                    <a href="http://rruff.info/mineral_list/locality.php?mineral_name={{mineral-species.mineral-name-plain}}" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=RRUFF&text={{mineral-species.mineral-name-plain}}&color=66CCFF'>
+                    </a>
 
+                    <a href="https://en.wikipedia.org/wiki/{{mineral-species.mineral-name-plain}}" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=Wikipedia&text={{mineral-species.mineral-name-plain}}&color=D14719'>
+                    </a>
+
+                    <a href="http://www.webmineral.com/data/{{mineral-species.mineral-name-plain}}.shtml" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=Web Mineral&text={{mineral-species.mineral-name-plain}}&color=66CD00'>
+                    </a>
+                </div>
 
                 <!--{{#if description}}-->
                     <!--<div>-->

--- a/html/map.html
+++ b/html/map.html
@@ -58,6 +58,21 @@
                 {{#if mineral-species.rruff-chemistry-html}}<div><strong>Mineral Chemistry:</strong> {{{mineral-species.rruff-chemistry-html}}}</div>{{/if}}
 
                 {{!-- link to MINDAT profile (badge?) --}}
+                <div class="badge">
+                    <a href="http://rruff.info/mineral_list/locality.php?mineral_name={{mineral-species.mineral-name-plain}}" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=RRUFF&text={{mineral-species.mineral-name-plain}}&color=66CCFF'>
+                    </a>
+                </div>
+                <div class="badge">
+                    <a href="https://en.wikipedia.org/wiki/{{mineral-species.mineral-name-plain}}" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=Wikipedia&text={{mineral-species.mineral-name-plain}}&color=D14719'>
+                    </a>
+                </div>
+                <div class="badge">
+                    <a href="http://www.webmineral.com/data/{{mineral-species.mineral-name-plain}}.shtml" target="_blank">
+                        <img style='vertical-align: middle' src='//dcotest.tw.rpi.edu/badges/badge?title=Web Mineral&text={{mineral-species.mineral-name-plain}}&color=66CD00'>
+                    </a>
+                </div>
             </td>
         </tr>
     </script>
@@ -319,6 +334,11 @@
 
         #facetview_rightcol {
             margin-top: 10px;
+        }
+        
+        div.badge {
+            margin: 5px;
+            height: 20%;
         }
 
     </style>


### PR DESCRIPTION
<img width="732" alt="screen shot 2016-04-06 at 9 27 26 pm" src="https://cloud.githubusercontent.com/assets/11859381/14337793/1b6d027a-fc3f-11e5-955f-64400b78fe41.png">
<img width="594" alt="screen shot 2016-04-06 at 9 07 26 pm" src="https://cloud.githubusercontent.com/assets/11859381/14337795/23454d5e-fc3f-11e5-861e-1b5a18a6b5e7.png">
